### PR TITLE
add comparison vs. semantic-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ Change default avatar image #public Closes [ENG-1234]
 QA
 default avatar image should be a penguin [ENG-1234]
 ```
+
+## FAQ:
+Q: Why use this over [semantic-release](https://github.com/semantic-release/semantic-release)?
+
+A: Semantic-release's [slack plugin](https://github.com/juliuscc/semantic-release-slack-bot) as of 05/21 does not generate an extended changelog. Semantic Release does not have a plugin for tagging github PR's or tickets either, as far as I am aware.


### PR DESCRIPTION
I was thinking about migrating us over to semantic-release but I took a look and it doesn't have the specifications we want.